### PR TITLE
Add canonical naming for execution ports

### DIFF
--- a/node_interfaces/interface_branch_v1.go
+++ b/node_interfaces/interface_branch_v1.go
@@ -16,8 +16,8 @@ const Branch_v1_Input_exec core.InputId = "exec"
 // Outputs (o) ==> 
 
 // 
-const Branch_v1_Output_otherwise core.OutputId = "otherwise"
+const Branch_v1_Output_exec_otherwise core.OutputId = "exec-otherwise"
 // 
-const Branch_v1_Output_then core.OutputId = "then"
+const Branch_v1_Output_exec_then core.OutputId = "exec-then"
 
 

--- a/node_interfaces/interface_gh-action_v1.go
+++ b/node_interfaces/interface_gh-action_v1.go
@@ -16,6 +16,6 @@ const Gh_action_v1_Input_env core.InputId = "env"
 // 
 const Gh_action_v1_Output_exec core.OutputId = "exec"
 // 
-const Gh_action_v1_Output_exec_err core.OutputId = "exec_err"
+const Gh_action_v1_Output_exec_err core.OutputId = "exec-err"
 
 

--- a/node_interfaces/interface_run_v1.go
+++ b/node_interfaces/interface_run_v1.go
@@ -22,9 +22,9 @@ const Run_v1_Input_shell core.InputId = "shell"
 // Outputs (o) ==> 
 
 // 
-const Run_v1_Output_exec_err core.OutputId = "exec_err"
+const Run_v1_Output_exec_err core.OutputId = "exec-err"
 // 
-const Run_v1_Output_exec_success core.OutputId = "exec_success"
+const Run_v1_Output_exec_success core.OutputId = "exec-success"
 // 
 const Run_v1_Output_exit_code core.OutputId = "exit_code"
 // 

--- a/nodes/branch@v1.go
+++ b/nodes/branch@v1.go
@@ -28,12 +28,12 @@ func (n *BranchNode) ExecuteImpl(c core.ExecutionContext) error {
 	}
 
 	if condition {
-		err = n.Execute(n.Executions[ni.Branch_v1_Output_then], c)
+		err = n.Execute(n.Executions[ni.Branch_v1_Output_exec_then], c)
 		if err != nil {
 			return u.Throw(err)
 		}
 	} else {
-		err = n.Execute(n.Executions[ni.Branch_v1_Output_otherwise], c)
+		err = n.Execute(n.Executions[ni.Branch_v1_Output_exec_otherwise], c)
 		if err != nil {
 			return u.Throw(err)
 		}

--- a/nodes/branch@v1.yml
+++ b/nodes/branch@v1.yml
@@ -9,11 +9,11 @@ style:
   body:
     background: linear-gradient(to right, rgb(117 53 145), rgb(125 18 157))
 outputs:
-  then:
+  exec-then:
     exec: true
     name: Then
     index: 0
-  otherwise:
+  exec-otherwise:
     exec: true
     name: Otherwise
     index: 1

--- a/nodes/gh-action@v1.yml
+++ b/nodes/gh-action@v1.yml
@@ -8,7 +8,7 @@ outputs:
   exec:
     exec: true
     index: 0
-  exec_err:
+  exec-err:
     exec: true
     index: 1
 inputs:

--- a/nodes/run@v1.yml
+++ b/nodes/run@v1.yml
@@ -10,11 +10,11 @@ style:
   body:
     background: '#292929'
 outputs:
-  exec_success:
+  exec-success:
     name: Success
     exec: true
     index: 0
-  exec_err:
+  exec-err:
     name: Error
     exec: true
     index: 1


### PR DESCRIPTION
This PR introduces defines the naming convention for execution ports. These must be named `exec-?[\w-]+` and have the `exec` attribute set to `true`. This check is validated during start. This also fixes #1 