### PR TITLE
Bake build version into binary

### DIFF
--- a/.github/workflows/graphs/build-and-publish.yml
+++ b/.github/workflows/graphs/build-and-publish.yml
@@ -134,8 +134,9 @@ nodes:
       y: 870
     inputs:
       script: >-
-        GOOS=linux GOARCH=amd64 go build -tags=github_impl -o
-        dist-linux/graph-runner-linux-x64 .
+        GOOS=linux GOARCH=amd64 go build -ldflags "-X
+        actionforge/graph-runner/core.Version=$GITHUB_REF_NAME"
+        -tags=github_impl -o dist-linux/graph-runner-linux-x64 .
 
         tar -cvf graph-runner-linux.tar -C dist-linux .
     settings:
@@ -157,8 +158,9 @@ nodes:
       y: 1200
     inputs:
       script: >-
-        GOOS=windows GOARCH=amd64 go build -tags=github_impl -o
-        dist-windows/graph-runner-windows-x64.exe .
+        GOOS=windows GOARCH=amd64 go build -ldflags "-X
+        actionforge/graph-runner/core.Version=$GITHUB_REF_NAME"
+        -tags=github_impl -o dist-windows/graph-runner-windows-x64.exe .
     settings:
       folded: false
   - id: blueberry-lemon-orange
@@ -189,11 +191,13 @@ nodes:
       y: 1530
     inputs:
       script: >-
-        GOOS=darwin GOARCH=arm64 go build -tags=github_impl -o
-        dist-macos/graph-runner-macos-arm64 .
+        GOOS=darwin GOARCH=arm64 go build -ldflags "-X
+        actionforge/graph-runner/core.Version=$GITHUB_REF_NAME"
+        -tags=github_impl -o dist-macos/graph-runner-macos-arm64 .
 
-        GOOS=darwin GOARCH=amd64 go build -tags=github_impl -o
-        dist-macos/graph-runner-macos-x64 .
+        GOOS=darwin GOARCH=amd64 go build -ldflags "-X
+        actionforge/graph-runner/core.Version=$GITHUB_REF_NAME"
+        -tags=github_impl -o dist-macos/graph-runner-macos-x64 .
 
         tar -cvf graph-runner-macos.tar -C dist-macos .
     settings:

--- a/.github/workflows/graphs/build-and-publish.yml
+++ b/.github/workflows/graphs/build-and-publish.yml
@@ -103,6 +103,42 @@ connections:
     dst:
       node: branch-v1-pink-purple-koala
       port: condition
+  - src:
+      node: env-get-v1-strawberry-banana-cranberry
+      port: env
+    dst:
+      node: string-fmt-v1-giraffe-gray-plum
+      port: input[0]
+  - src:
+      node: env-get-v1-strawberry-banana-cranberry
+      port: env
+    dst:
+      node: string-fmt-v1-dolphin-monkey-grape
+      port: input[0]
+  - src:
+      node: env-get-v1-strawberry-banana-cranberry
+      port: env
+    dst:
+      node: string-fmt-v1-squirrel-strawberry-plum
+      port: input[0]
+  - src:
+      node: string-fmt-v1-dolphin-monkey-grape
+      port: result
+    dst:
+      node: orange-watermelon-lion
+      port: name
+  - src:
+      node: string-fmt-v1-giraffe-gray-plum
+      port: result
+    dst:
+      node: blueberry-lemon-orange
+      port: name
+  - src:
+      node: string-fmt-v1-squirrel-strawberry-plum
+      port: result
+    dst:
+      node: rabbit-dolphin-raspberry
+      port: name
 nodes:
   - id: gh-start
     type: gh-start@v1
@@ -130,8 +166,8 @@ nodes:
   - id: penguin-coconut-gray
     type: run@v1
     position:
-      x: 2780
-      y: 870
+      x: 2830
+      y: 730
     inputs:
       script: >-
         GOOS=linux GOARCH=amd64 go build -ldflags "-X
@@ -144,8 +180,8 @@ nodes:
   - id: rabbit-dolphin-raspberry
     type: github.com/actions/upload-artifact@v3.1.3
     position:
-      x: 3090
-      y: 880
+      x: 3250
+      y: 1180
     inputs:
       name: graph-runner-linux-x64
       path: graph-runner-linux.tar
@@ -154,8 +190,8 @@ nodes:
   - id: yellow-kangaroo-pineapple
     type: run@v1
     position:
-      x: 2780
-      y: 1200
+      x: 2830
+      y: 1060
     inputs:
       script: >-
         GOOS=windows GOARCH=amd64 go build -ldflags "-X
@@ -166,8 +202,8 @@ nodes:
   - id: blueberry-lemon-orange
     type: github.com/actions/upload-artifact@v3.1.3
     position:
-      x: 3090
-      y: 1210
+      x: 3250
+      y: 1480
     inputs:
       name: graph-runner-windows-x64
       path: dist-windows/graph-runner-windows-x64.exe
@@ -187,8 +223,8 @@ nodes:
   - id: giraffe-monkey-plum
     type: run@v1
     position:
-      x: 2780
-      y: 1530
+      x: 2830
+      y: 1390
     inputs:
       script: >-
         GOOS=darwin GOARCH=arm64 go build -ldflags "-X
@@ -205,8 +241,8 @@ nodes:
   - id: orange-watermelon-lion
     type: github.com/actions/upload-artifact@v3.1.3
     position:
-      x: 3090
-      y: 1540
+      x: 3250
+      y: 1790
     inputs:
       name: graph-runner-macos
       path: graph-runner-macos.tar
@@ -215,7 +251,7 @@ nodes:
   - id: blue-monkey-tiger
     type: parallel-exec@v1
     position:
-      x: 2480
+      x: 2530
       y: 1100
     outputs:
       exec[0]: ''
@@ -282,6 +318,45 @@ nodes:
     inputs:
       name: cover
       path: cover.html
+    settings:
+      folded: false
+  - id: string-fmt-v1-squirrel-strawberry-plum
+    type: string-fmt@v1
+    position:
+      x: 2810
+      y: 1730
+    inputs:
+      input[0]: null
+      fmt: graph-runner-linux-%v.tar
+    settings:
+      folded: false
+  - id: string-fmt-v1-giraffe-gray-plum
+    type: string-fmt@v1
+    position:
+      x: 2810
+      y: 1940
+    inputs:
+      input[0]: null
+      fmt: graph-runner-windows-x64-%v
+    settings:
+      folded: false
+  - id: string-fmt-v1-dolphin-monkey-grape
+    type: string-fmt@v1
+    position:
+      x: 2810
+      y: 2160
+    inputs:
+      input[0]: null
+      fmt: graph-runner-macos-%v.tar
+    settings:
+      folded: false
+  - id: env-get-v1-strawberry-banana-cranberry
+    type: env-get@v1
+    position:
+      x: 2480
+      y: 2050
+    inputs:
+      env: GITHUB_REF_NAME
     settings:
       folded: false
 registries:

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"actionforge/graph-runner/core"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -9,7 +10,7 @@ import (
 var cmdRoot = &cobra.Command{
 	Use:     "graph-runner",
 	Short:   "Graph runner is a tool for running action graphs.",
-	Version: "0.1a",
+	Version: core.GetFulllVersionInfo(),
 	Run: func(cmd *cobra.Command, args []string) {
 		_ = cmd.Help()
 	},

--- a/core/build.go
+++ b/core/build.go
@@ -1,0 +1,60 @@
+package core
+
+import (
+	"fmt"
+	"runtime/debug"
+)
+
+var (
+	// To set version number, build with:
+	// $ go build -ldflags "-X actionforge/graph-runner/core.Version=1.2.3"
+	Version string
+)
+
+func GetBuildSettings() (map[string]string, bool) {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return nil, false
+	}
+
+	settings := map[string]string{}
+
+	for _, s := range bi.Settings {
+		settings[s.Key] = s.Value
+	}
+	return settings, true
+
+}
+
+func GetAppVersion() string {
+	if Version != "" {
+		return Version
+	} else {
+		return "development build"
+	}
+}
+
+func GetFulllVersionInfo() string {
+
+	bi, ok := GetBuildSettings()
+	if !ok {
+		return "invalid build info"
+	}
+
+	if Version == "" {
+		Version = "unknown"
+	}
+
+	// if git status returned no changes
+	modified := ""
+	if bi["vcs.modified"] == "true" {
+		modified = ", workdir modified"
+	}
+
+	revision := bi["vcs.revision"]
+	if len(revision) > 8 {
+		revision = revision[:8]
+	}
+
+	return fmt.Sprintf("%s (%s %s, %s, %s%s)", Version, bi["GOOS"], bi["GOARCH"], bi["vcs.time"], revision, modified)
+}

--- a/core/build.go
+++ b/core/build.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	// To set version number, build with:
-	// $ go build -ldflags "-X actionforge/graph-runner/core.Version=1.2.3"
+	// $ go build -ldflags "-X actionforge/graph-runner/core.Version=v1.2.3"
 	Version string
 )
 


### PR DESCRIPTION
This PR bakes the build version into the binary when they are built through the GH actions workflow. The version can be added as follows:

```bash
go build -ldflags "-X actionforge/graph-runner/core.Version=v1.2.3"
```