### PR TITLE
Refactor gh secret and context management 

### DIFF
--- a/cmd/cmd_generate.go
+++ b/cmd/cmd_generate.go
@@ -1,6 +1,5 @@
 //go build generate_node_stubs
 //go:build generate_node_stubs
-// +build generate_node_stubs
 
 package cmd
 

--- a/cmd/cmd_root.go
+++ b/cmd/cmd_root.go
@@ -2,6 +2,9 @@ package cmd
 
 import (
 	"actionforge/graph-runner/core"
+	"actionforge/graph-runner/utils"
+	"flag"
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -20,4 +23,21 @@ func Execute() {
 	_ = cmdRoot.PersistentFlags().Parse(os.Args[1:])
 
 	_ = cmdRoot.Execute()
+}
+
+func init() {
+	flag.Usage = func() {
+		fmt.Print("\n")
+		fmt.Fprintf(os.Stderr, "Usage: %s", os.Args[0])
+		flag.VisitAll(func(f *flag.Flag) {
+			defValue := f.DefValue
+			if defValue == "" {
+				defValue = "'...'"
+			}
+			fmt.Fprintf(os.Stderr, " -%s=%s", f.Name, defValue)
+		})
+		fmt.Print("\n\n")
+	}
+
+	utils.LoadEnvOnce()
 }

--- a/cmd/cmd_run.go
+++ b/cmd/cmd_run.go
@@ -2,16 +2,13 @@ package cmd
 
 import (
 	u "actionforge/graph-runner/utils"
-	"flag"
 	"fmt"
 	"os"
-	"strings"
 
 	// initialize all nodes
 	"actionforge/graph-runner/core"
 	_ "actionforge/graph-runner/nodes"
 
-	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 )
 
@@ -65,66 +62,4 @@ func init() {
 	cmdRoot.AddCommand(cmdRun)
 
 	cmdRun.Flags().String("graph_file", "", "The graph file to run")
-}
-
-func init() {
-	loadEnvFile := os.Getenv("LOAD_ENV_FILE")
-	if loadEnvFile != "" {
-		_ = godotenv.Load()
-	}
-
-	flag.Usage = func() {
-		fmt.Print("\n")
-		fmt.Fprintf(os.Stderr, "Usage: %s", os.Args[0])
-		flag.VisitAll(func(f *flag.Flag) {
-			defValue := f.DefValue
-			if defValue == "" {
-				defValue = "'...'"
-			}
-			fmt.Fprintf(os.Stderr, " -%s=%s", f.Name, defValue)
-		})
-		fmt.Print("\n\n")
-	}
-
-	// Extract secrets and github tokens if available
-	if os.Getenv("GITHUB_ACTIONS") == "true" {
-
-		githubToken := os.Getenv("ACTIONS_RUNTIME_TOKEN")
-		if githubToken == "" {
-			panic("ACTIONS_RUNTIME_TOKEN is empty")
-		}
-
-		core.G_githubToken = githubToken
-
-		for _, env := range os.Environ() {
-			if strings.HasPrefix(strings.ToUpper(env), "SECRET_") {
-				pair := strings.SplitN(env, "=", 2)
-				if len(pair) == 1 {
-					// empty secrets are valid
-					core.G_secrets[pair[0]] = ""
-				} else if len(pair) == 2 {
-					key := strings.TrimPrefix(strings.ToUpper(pair[0]), "SECRET_")
-					value := pair[1]
-
-					core.G_secrets[key] = value
-					os.Unsetenv(pair[0])
-				} else {
-					fmt.Println("WARN: Invalid secret: ", pair[0])
-				}
-			}
-		}
-
-		githubRepo := os.Getenv("GITHUB_REPOSITORY")
-		if githubRepo == "" {
-			panic("GITHUB_REPOSITORY is empty")
-		}
-
-		githubRepoPair := strings.Split(githubRepo, "/")
-		if githubRepoPair == nil || len(githubRepoPair) != 2 {
-			panic("GITHUB_REPOSITORY expected to be in the format of 'org/repo'")
-		}
-
-		core.G_repositoryOrg = githubRepoPair[0]
-		core.G_repositoryName = githubRepoPair[1]
-	}
 }

--- a/cmd/cmd_update.go
+++ b/cmd/cmd_update.go
@@ -1,6 +1,5 @@
 //go build update_registry
 //go:build update_registry
-// +build update_registry
 
 package cmd
 

--- a/cmd/cmd_update_utils_mongo.go
+++ b/cmd/cmd_update_utils_mongo.go
@@ -1,6 +1,5 @@
 //go build update_registry
 //go:build update_registry
-// +build update_registry
 
 package cmd
 

--- a/core/github.go
+++ b/core/github.go
@@ -1,8 +1,0 @@
-package core
-
-var (
-	G_githubToken    string
-	G_secrets        = make(map[string]string, 0)
-	G_repositoryOrg  string
-	G_repositoryName string
-)

--- a/nodes/env-array@v1.go
+++ b/nodes/env-array@v1.go
@@ -1,5 +1,4 @@
 //go:build github_impl
-// +build github_impl
 
 package nodes
 

--- a/nodes/env-get@v1.go
+++ b/nodes/env-get@v1.go
@@ -1,5 +1,4 @@
 //go:build github_impl
-// +build github_impl
 
 package nodes
 

--- a/nodes/gh-action@v1.go
+++ b/nodes/gh-action@v1.go
@@ -263,13 +263,6 @@ func parseNodeTypeUri(nodeTypeUri string) (registry string, owner string, regnam
 }
 
 func init() {
-	// Use the input token that is provided by the user, or passed as default,
-	// otherwise fall back to use the runtime token that is provided by github.
-	if os.Getenv("INPUT_TOKEN") != "" {
-		core.G_secrets["secrets.GITHUB_TOKEN"] = os.Getenv("INPUT_TOKEN")
-	} else {
-		core.G_secrets["secrets.GITHUB_TOKEN"] = os.Getenv("ACTIONS_RUNTIME_TOKEN")
-	}
 
 	err := core.RegisterNodeFactory(ghActionNodeDefinition, func(ctx interface{}) (core.NodeRef, error) {
 
@@ -291,7 +284,7 @@ func init() {
 		_, err = os.Stat(actionFolder)
 		if os.IsNotExist(err) {
 			// Clone the entire repo but don't check out yet since HEAD might not be the requested ref.
-			cloneUrl := fmt.Sprintf("https://%s@github.com/%s/%s", core.G_githubToken, owner, name)
+			cloneUrl := fmt.Sprintf("https://%s@github.com/%s/%s", ghActionsRuntimeToken, owner, name)
 			c := exec.Command("git", "clone", "--no-checkout", cloneUrl, actionFolder)
 			// c.Stdout = os.Stdout
 			c.Stderr = os.Stderr

--- a/nodes/gh-action@v1.go
+++ b/nodes/gh-action@v1.go
@@ -1,5 +1,4 @@
 //go:build github_impl
-// +build github_impl
 
 package nodes
 

--- a/nodes/gh-action@v1_test.go
+++ b/nodes/gh-action@v1_test.go
@@ -9,8 +9,11 @@ import (
 )
 
 func TestReplaceContextVariables(t *testing.T) {
-
 	// Fill github context variables with some dummy data
+
+	// GITHUB_ACTIONS must be set in order to initialize the github context
+	// structures in the init() function of gh-action.
+	os.Setenv("GITHUB_ACTIONS", "true")
 
 	os.Setenv("GITHUB_ACTOR", "actioncat")
 	os.Setenv("GITHUB_BASE_REF", "main")
@@ -21,8 +24,13 @@ func TestReplaceContextVariables(t *testing.T) {
 	os.Setenv("GITHUB_REF", "refs/heads/main")
 	os.Setenv("GITHUB_SHA", "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0")
 	os.Setenv("GITHUB_REPOSITORY", "my-user/my-repo")
-	os.Setenv("GITHUB_TOKEN", "ghp_1234567890abcdef1234567890abcdef12345678")
+	os.Setenv("INPUT_TOKEN", "ghp_1234567890abcdef1234567890abcdef12345678")
 	os.Setenv("GITHUB_WORKFLOW", "CI Build")
+
+	// Since the env variables are not coming from the parent
+	// process and were instead set manually above, the github
+	// context variables need to be initialized again.
+	initGhContexts()
 
 	// Define test cases
 	testCases := []struct {
@@ -153,13 +161,25 @@ func TestReplaceContextVariables(t *testing.T) {
 			},
 			expectedOutput: "Long variable: LongValue.",
 		},
+		{
+			name:           "Check github.token",
+			input:          "Secret is ${{ github.token }}.",
+			inputValues:    map[core.InputId]interface{}{},
+			expectedOutput: "Secret is ghp_1234567890abcdef1234567890abcdef12345678.",
+		},
+		{
+			name:           "Check github.token",
+			input:          "Secret is ${{ secrets.GITHUB_TOKEN }}.",
+			inputValues:    map[core.InputId]interface{}{},
+			expectedOutput: "Secret is ghp_1234567890abcdef1234567890abcdef12345678.",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			output := ReplaceContextVariables(tc.input, tc.inputValues)
 			if output != tc.expectedOutput {
-				t.Errorf("Output should match expected output")
+				t.Errorf("Output should match expected output, but got: %s", output)
 			}
 		})
 	}

--- a/nodes/gh-action@v1_test.go
+++ b/nodes/gh-action@v1_test.go
@@ -1,5 +1,4 @@
 //go:build github_impl
-// +build github_impl
 
 package nodes
 

--- a/nodes/gh-secret@v1.go
+++ b/nodes/gh-secret@v1.go
@@ -32,15 +32,11 @@ func (n *GhSecretsNode) OutputValueById(c core.ExecutionContext, outputId core.O
 
 	var secretValue string
 
-	if secretName == "GITHUB_TOKEN" {
-		secretValue = core.G_githubToken
-	} else {
-		var ok bool
-		secretValue, ok = core.G_secrets[secretName]
-		if !ok {
-			// return an empty string if the secret is not found
-			return "", nil
-		}
+	var ok bool
+	secretValue, ok = ghSecrets[secretName]
+	if !ok {
+		// return an empty string if the secret is not found
+		return "", nil
 	}
 
 	return fmt.Sprintf("%s%s", prefix, secretValue), nil

--- a/nodes/gh-secret@v1.go
+++ b/nodes/gh-secret@v1.go
@@ -1,5 +1,4 @@
 //go:build github_impl
-// +build github_impl
 
 package nodes
 

--- a/nodes/gh-start@v1.go
+++ b/nodes/gh-start@v1.go
@@ -1,5 +1,4 @@
 //go:build github_impl
-// +build github_impl
 
 package nodes
 

--- a/nodes/gh-utils.go
+++ b/nodes/gh-utils.go
@@ -23,32 +23,8 @@ var (
 	nodeTypeUriRegex     *regexp.Regexp
 )
 
-var githubContext = make(map[string]string)
-
-var secretsContext = map[string]string{}
-
-func githubContextInit() {
-	githubContext["github.job"] = os.Getenv("GITHUB_JOB")
-	githubContext["github.actor"] = os.Getenv("GITHUB_ACTOR")
-	githubContext["github.base_ref"] = os.Getenv("GITHUB_BASE_REF")
-	githubContext["github.event_name"] = os.Getenv("GITHUB_EVENT_NAME")
-	githubContext["github.event_path"] = os.Getenv("GITHUB_EVENT_PATH")
-	githubContext["github.head_ref"] = os.Getenv("GITHUB_HEAD_REF")
-	githubContext["github.ref"] = os.Getenv("GITHUB_REF")
-	githubContext["github.repository"] = os.Getenv("GITHUB_REPOSITORY")
-	githubContext["github.sha"] = os.Getenv("GITHUB_SHA")
-	githubContext["github.workflow"] = os.Getenv("GITHUB_WORKFLOW")
-	githubContext["github.workspace"] = os.Getenv("GITHUB_WORKSPACE")
-	githubContext["github.token"] = os.Getenv("INPUT_TOKEN")
-
-	// TODO: (Seb) Add all remaining env vars
-	// See https://docs.github.com/en/actions/learn-github-actions/contexts
-}
-
 func getGithubVarsRe() *regexp.Regexp {
 	onceGithubVarsRe.Do(func() {
-		githubContextInit()
-
 		githubVarsRe = regexp.MustCompile(`\$\{\{\s*(env|github|inputs|secrets)\.[\w]+\s*\}\}`)
 	})
 	return githubVarsRe
@@ -220,7 +196,7 @@ func ReplaceContextVariables(input string, inputValues map[core.InputId]interfac
 			}
 			return ""
 		} else if strings.HasPrefix(contextVar, "github.") {
-			envVar, exists := githubContext[contextVar]
+			envVar, exists := ghContext[contextVar]
 			if exists {
 				return envVar
 			}
@@ -232,7 +208,7 @@ func ReplaceContextVariables(input string, inputValues map[core.InputId]interfac
 			}
 			return ""
 		} else if strings.HasPrefix(contextVar, "secrets.") {
-			envVar, exists := secretsContext[contextVar]
+			envVar, exists := ghSecrets[contextVar]
 			if exists {
 				return envVar
 			}

--- a/nodes/gh-utils.go
+++ b/nodes/gh-utils.go
@@ -1,5 +1,4 @@
 //go:build github_impl
-// +build github_impl
 
 package nodes
 

--- a/nodes/gh.go
+++ b/nodes/gh.go
@@ -1,0 +1,77 @@
+//go:build github_impl
+
+package nodes
+
+import (
+	"actionforge/graph-runner/utils"
+	"fmt"
+	"os"
+	"strings"
+)
+
+var (
+	// This is the token of `ACTIONS_RUNTIME_TOKEN` that is used to
+	// communicate with certain github APIs, like when github actions
+	// are pulled from github.com.
+	ghActionsRuntimeToken string
+
+	// This is the map of secrets that are available during the execution
+	// of the action graph. The values contain the context name and
+	// the secret value. Example: secrets.input1 github.token
+	ghSecrets = make(map[string]string, 0)
+
+	// this is the map of context variables that are available to the action
+	ghContext = make(map[string]string)
+)
+
+func AddGhSecret(name string, secret string) {
+	ghSecrets[name] = secret
+}
+
+func RemoveGhSecret(name string) {
+	delete(ghSecrets, name)
+}
+
+func initGhContexts() {
+
+	ghContext["github.workspace"] = os.Getenv("GITHUB_WORKSPACE")
+	ghContext["github.repository"] = os.Getenv("GITHUB_REPOSITORY")
+	ghContext["github.job"] = os.Getenv("GITHUB_JOB")
+	ghContext["github.ref"] = os.Getenv("GITHUB_REF")
+	ghContext["github.sha"] = os.Getenv("GITHUB_SHA")
+	ghContext["github.event_name"] = os.Getenv("GITHUB_EVENT_NAME")
+	ghContext["github.workflow"] = os.Getenv("GITHUB_WORKFLOW")
+
+	// As outlined in the documentation, secrets.GITHUB_TOKEN and github.token
+	// are functionally equivalent. See:
+	// https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+	ghContext["github.token"] = os.Getenv("INPUT_TOKEN")
+	ghSecrets["secrets.GITHUB_TOKEN"] = os.Getenv("INPUT_TOKEN")
+
+	ghActionsRuntimeToken = os.Getenv("ACTIONS_RUNTIME_TOKEN")
+
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(strings.ToUpper(env), "SECRET_") {
+			pair := strings.SplitN(env, "=", 2)
+			if len(pair) == 1 {
+				// empty secrets are valid
+				ghSecrets[pair[0]] = ""
+			} else if len(pair) == 2 {
+				key := strings.TrimPrefix(strings.ToUpper(pair[0]), "SECRET_")
+				value := pair[1]
+
+				ghSecrets[key] = value
+				os.Unsetenv(pair[0])
+			} else {
+				fmt.Println("WARN: Invalid secret: ", pair[0])
+			}
+		}
+	}
+}
+
+func init() {
+
+	utils.LoadEnvOnce()
+
+	initGhContexts()
+}

--- a/nodes/ngh-utils.go
+++ b/nodes/ngh-utils.go
@@ -1,5 +1,4 @@
 //go:build !github_impl
-// +build !github_impl
 
 package nodes
 

--- a/nodes/run@v1_test.go
+++ b/nodes/run@v1_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package nodes
 

--- a/nodes/start@v1.go
+++ b/nodes/start@v1.go
@@ -1,5 +1,3 @@
-//go:build github_impl
-
 package nodes
 
 import (

--- a/nodes/start@v1.go
+++ b/nodes/start@v1.go
@@ -1,5 +1,4 @@
 //go:build github_impl
-// +build github_impl
 
 package nodes
 

--- a/nodes/test@v1_test.go
+++ b/nodes/test@v1_test.go
@@ -1,5 +1,4 @@
 //go:build integration_tests
-// +build integration_tests
 
 package nodes
 

--- a/system_tests/cli_base_test.go
+++ b/system_tests/cli_base_test.go
@@ -1,5 +1,4 @@
 //go:build system_tests
-// +build system_tests
 
 package system_tests
 

--- a/system_tests/run_github_test.go
+++ b/system_tests/run_github_test.go
@@ -1,5 +1,4 @@
 //go:build system_tests
-// +build system_tests
 
 package system_tests
 

--- a/system_tests/run_github_test.go
+++ b/system_tests/run_github_test.go
@@ -1,9 +1,9 @@
-//go:build system_tests
+//go:build system_tests && github_impl
 
 package system_tests
 
 import (
-	"actionforge/graph-runner/core"
+	"actionforge/graph-runner/nodes"
 	"actionforge/graph-runner/utils"
 	"fmt"
 	"testing"
@@ -19,8 +19,8 @@ type testCase struct {
 func Test_Secret(t *testing.T) {
 	defer utils.LoggerString.Clear()
 
-	core.G_secrets["API_KEY_123"] = "THIS_IS_A_SECRET"
-	defer delete(core.G_secrets, "API_KEY_123")
+	nodes.AddGhSecret("API_KEY_123", "THIS_IS_A_SECRET")
+	defer nodes.RemoveGhSecret("API_KEY_123")
 
 	// Test the run node, env node, and string format node.
 	exitCode, err := runGraphFile("system_tests/test_secret.yml")

--- a/system_tests/run_test.go
+++ b/system_tests/run_test.go
@@ -1,5 +1,4 @@
 //go:build system_tests
-// +build system_tests
 
 package system_tests
 

--- a/unit_tests/context_test.go
+++ b/unit_tests/context_test.go
@@ -1,5 +1,4 @@
 //go:build unit_tests
-// +build unit_tests
 
 package unit_tests
 

--- a/unit_tests/core_test.go
+++ b/unit_tests/core_test.go
@@ -1,5 +1,4 @@
 //go:build unit_tests
-// +build unit_tests
 
 package unit_tests
 

--- a/unit_tests/utils_test.go
+++ b/unit_tests/utils_test.go
@@ -1,5 +1,4 @@
 //go:build unit_tests
-// +build unit_tests
 
 package unit_tests
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -9,7 +9,12 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
+
+	"github.com/joho/godotenv"
 )
+
+var envFileOnce sync.Once
 
 // Inline-if alternative in Go. Example:
 // e ? a : b becomes If(e, a, b)
@@ -19,6 +24,15 @@ func If[E bool, T any](exp E, a T, b T) T {
 	} else {
 		return b
 	}
+}
+
+func LoadEnvOnce() {
+	envFileOnce.Do(func() {
+		loadEnvFile := os.Getenv("LOAD_ENV_FILE")
+		if loadEnvFile != "" {
+			_ = godotenv.Load()
+		}
+	})
 }
 
 func NormalizeLineEndings(s string) string {


### PR DESCRIPTION
This PR comes with a refactoring out the gh secret and context management, including several bugfixes.

The context object `github.token` is removed as it doesn't exist, and instead the proper objects `github.token` and `secrets.GITHUB_TOKEN` are introduced, both of which are functionally equivalent. They are both added to the unit tests as well.