### PR TITLE
Add freeze system test

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
             "version": "3.9"
         },
         "ghcr.io/devcontainers/features/go:1": {
-            "version": "1.21"
+            "version": "1.22"
         }
     },
     "remoteUser": "vscode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,8 @@
                 "ms-python.python",
                 "github.vscode-github-actions",
                 "eamodio.gitlens",
-                "shd101wyy.markdown-preview-enhanced"
+                "shd101wyy.markdown-preview-enhanced",
+                "Actionforge.actionforge"
             ]
         }
     },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -45,6 +45,6 @@
     "workspaceFolder": "/workspaces/graph-runner",
     "mounts": [
         "source=${localEnv:HOME}${localEnv:USERPROFILE}/Desktop,target=/home/vscode/Desktop,type=bind,consistency=consistent",
-        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/root/.ssh,type=bind,consistency=consistent"
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=consistent"
     ]
 }

--- a/.github/workflows/graphs/build-and-publish.yml
+++ b/.github/workflows/graphs/build-and-publish.yml
@@ -214,7 +214,7 @@ nodes:
       x: 700
       y: 970
     inputs:
-      go-version: '1.21'
+      go-version: '1.22'
     settings:
       folded: false
   - id: penguin-coconut-gray

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -8,6 +8,7 @@
         "ms-python.python",
         "github.vscode-github-actions",
         "eamodio.gitlens",
-        "shd101wyy.markdown-preview-enhanced"
+        "shd101wyy.markdown-preview-enhanced",
+        "Actionforge.actionforge"
     ]
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ## Build
 ##
 
-FROM golang:1.21.5-alpine3.18 AS build
+FROM golang:1.22.0-alpine3.19 AS build
 
 WORKDIR /app
 

--- a/cmd/cmd_freeze.go
+++ b/cmd/cmd_freeze.go
@@ -171,6 +171,12 @@ func downloadAndExtractGraphRunner(dstDir string) (dir string, err error) {
 }
 
 func downloadAndExtractGo(dstDir string) (dir string, err error) {
+	// Use the go executable in the path if it exists, otherwise download it
+	if testGoExecutable() == nil {
+		return "go", nil
+	}
+
+
 	goBin := filepath.Join(dstDir, "go", "bin", "go")
 	if runtime.GOOS == "windows" {
 		goBin += ".exe"
@@ -252,6 +258,15 @@ func getJson(url string, target interface{}) error {
 	defer r.Body.Close()
 
 	return json.NewDecoder(r.Body).Decode(target)
+}
+
+func testGoExecutable() error {
+	cmd := exec.Command("go", "version")
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to execute `go version`: %v", err)
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/cmd_freeze.go
+++ b/cmd/cmd_freeze.go
@@ -109,7 +109,7 @@ var cmdFreeze = &cobra.Command{
 			log.Fatal(err)
 		}
 
-		fmt.Printf("🚀 Binary written to %s\n", output)
+		fmt.Printf("🚀 Binary written to %s\n", absOutput)
 	},
 }
 
@@ -164,18 +164,17 @@ func downloadAndExtractGraphRunner(dstDir string) (dir string, err error) {
 	fmt.Println("Unzipping graph-runner")
 	err = utils.Unzip(repoZip, dstDir)
 	if err != nil {
-		return "", errors.New("Error unzipping graph-runner")
+		return "", fmt.Errorf("Error unzipping graph-runner: %v", err)
 	}
 
 	return dir, nil
 }
 
 func downloadAndExtractGo(dstDir string) (dir string, err error) {
-	// Use the go executable in the path if it exists, otherwise download it
+	// Use the go executable from the system if it exists, otherwise download it
 	if testGoExecutable() == nil {
 		return "go", nil
 	}
-
 
 	goBin := filepath.Join(dstDir, "go", "bin", "go")
 	if runtime.GOOS == "windows" {
@@ -235,13 +234,13 @@ func downloadAndExtractGo(dstDir string) (dir string, err error) {
 			fmt.Println("Untarring go")
 			err = utils.Untar(goZip, dstDir)
 			if err != nil {
-				return "", errors.New("Error unzipping graph-runner")
+				return "", fmt.Errorf("Error untarring graph-runner: %v", err)
 			}
 		} else if strings.HasSuffix(goFile.Filename, ".zip") {
 			fmt.Println("Unzipping go")
 			err = utils.Unzip(goZip, dstDir)
 			if err != nil {
-				return "", errors.New("Error unzipping graph-runner")
+				return "", fmt.Errorf("Error unzipping graph-runner: %v", err)
 			}
 		} else {
 			return "", errors.New("Unknown file type")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module actionforge/graph-runner
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1

--- a/nodes/gh-action@v1.go
+++ b/nodes/gh-action@v1.go
@@ -56,8 +56,8 @@ func (n *GhActionNode) ExecuteImpl(c core.ExecutionContext) error {
 		return fmt.Errorf("GITHUB_WORKSPACE not set")
 	}
 
-	environ := make([]string, len(os.Environ()))
-	for _, env := range os.Environ() {
+	environ := make([]string, 0)
+	for _, env := range utils.GetSanitizedEnviron() {
 		// remove all INPUT_ env as they are resolved in the next code block below
 		if !strings.HasPrefix(env, "INPUT_") {
 			environ = append(environ, env)

--- a/nodes/gh.go
+++ b/nodes/gh.go
@@ -74,7 +74,7 @@ func initGhContexts() {
 
 	ghActionsRuntimeToken = os.Getenv("ACTIONS_RUNTIME_TOKEN")
 
-	for _, env := range os.Environ() {
+	for _, env := range utils.GetSanitizedEnviron() {
 		if strings.HasPrefix(strings.ToUpper(env), "SECRET_") {
 			pair := strings.SplitN(env, "=", 2)
 			if len(pair) == 1 {

--- a/nodes/run@v1.go
+++ b/nodes/run@v1.go
@@ -56,7 +56,7 @@ func (n *RunNode) ExecuteImpl(c core.ExecutionContext) error {
 		envs[i] = ReplaceContextVariables(env, n.GetInputValues())
 	}
 
-	env := append(envs, os.Environ()...)
+	env := append(envs, utils.GetSanitizedEnviron()...)
 
 	tmpfilePath := "run-script-*"
 	if runtime.GOOS == "windows" {

--- a/system_tests/cli_base_test.go
+++ b/system_tests/cli_base_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -37,7 +38,6 @@ func Test_Cli(t *testing.T) {
 	}
 }
 
-/*
 func Test_Frozen(t *testing.T) {
 	actionHomeDir := utils.GetActionforgeDir()
 
@@ -99,4 +99,3 @@ func testFrozen(expected string) error {
 
 	return err
 }
-*/

--- a/system_tests/cli_base_test.go
+++ b/system_tests/cli_base_test.go
@@ -15,9 +15,12 @@ func TestMain(m *testing.M) {
 	cmd := exec.Command("go",
 		"build",
 		"--tags=github_impl",
+		"-ldflags",
+		"-X actionforge/graph-runner/core.Production=true",
 		".",
 	)
 	cmd.Dir = utils.FindProjectRoot()
+	cmd.Env = utils.GetSanitizedEnviron()
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		fmt.Println(string(output))
@@ -38,7 +41,7 @@ func Test_Cli(t *testing.T) {
 	}
 }
 
-func Test_Frozen(t *testing.T) {
+func Test_Freeze(t *testing.T) {
 	actionHomeDir := utils.GetActionforgeDir()
 
 	err := os.RemoveAll(actionHomeDir)
@@ -79,9 +82,16 @@ func buildFrozen(graphPath string) error {
 		"--output",
 		"frozen",
 	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	cmd.Env = utils.GetSanitizedEnviron()
 	cmd.Dir = utils.FindProjectRoot()
-	output, err := cmd.CombinedOutput()
-	fmt.Println(string(output))
+
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
 
 	return err
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -342,3 +342,14 @@ func GetActionforgeDir() string {
 	}
 	return filepath.Join(home, ".actionforge")
 }
+
+func GetSanitizedEnviron() []string {
+	env := os.Environ()
+	var sanitizedEnv []string
+	for _, e := range env {
+		if !strings.HasPrefix(e, "GRAPH_FILE=") {
+			sanitizedEnv = append(sanitizedEnv, e)
+		}
+	}
+	return sanitizedEnv
+}


### PR DESCRIPTION
This PR enables the system tests for the `freeze` command. In addition, the following minor changes and fixes:

- Bump Go to 1.22
- Fix Dev Containers
- `GRAPH_FILE` not spilled anymore into children processes