### PR TITLE
Evaluate context variables for github

### DIFF
--- a/nodes/env-array@v1.go
+++ b/nodes/env-array@v1.go
@@ -22,7 +22,7 @@ func (n *EnvArrayNode) OutputValueById(c core.ExecutionContext, outputId core.Ou
 	}
 
 	for i, env := range envs {
-		envs[i] = ReplaceContextVariables(env, n.GetInputValues())
+		envs[i] = ReplaceContextVariables(env)
 	}
 
 	return envs, nil

--- a/nodes/gh-action@v1.go
+++ b/nodes/gh-action@v1.go
@@ -56,14 +56,7 @@ func (n *GhActionNode) ExecuteImpl(c core.ExecutionContext) error {
 		return fmt.Errorf("GITHUB_WORKSPACE not set")
 	}
 
-	environ := make([]string, 0)
-	for _, env := range utils.GetSanitizedEnviron() {
-		// remove all INPUT_ env as they are resolved in the next code block below
-		if !strings.HasPrefix(env, "INPUT_") {
-			environ = append(environ, env)
-		}
-	}
-
+	environ := utils.GetSanitizedEnviron()
 	withInputs := ""
 
 	for inputName := range n.Inputs.GetInputDefs() {
@@ -71,7 +64,7 @@ func (n *GhActionNode) ExecuteImpl(c core.ExecutionContext) error {
 		if err != nil {
 			return err
 		}
-		v = ReplaceContextVariables(v, n.Inputs.GetInputValues())
+		v = ReplaceContextVariables(v)
 		environ = append(environ, fmt.Sprintf("INPUT_%v=%v", strings.ToUpper(string(inputName)), v))
 
 		withInputs += fmt.Sprintf(" %s: %s\n", inputName, v)
@@ -219,7 +212,7 @@ func (n *GhActionNode) ExecuteDocker(c core.ExecutionContext, workspace string, 
 
 	ContainerEntryArgs := make([]string, 0)
 	for _, arg := range n.actionRuns.Args {
-		ContainerEntryArgs = append(ContainerEntryArgs, ReplaceContextVariables(arg, n.Inputs.GetInputValues()))
+		ContainerEntryArgs = append(ContainerEntryArgs, ReplaceContextVariables(arg))
 	}
 
 	ci := ContainerInfo{

--- a/nodes/gh-action@v1_test.go
+++ b/nodes/gh-action@v1_test.go
@@ -3,7 +3,8 @@
 package nodes
 
 import (
-	"actionforge/graph-runner/core"
+	"bytes"
+	"encoding/json"
 	"os"
 	"testing"
 )
@@ -24,160 +25,143 @@ func TestReplaceContextVariables(t *testing.T) {
 	os.Setenv("GITHUB_REF", "refs/heads/main")
 	os.Setenv("GITHUB_SHA", "a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0")
 	os.Setenv("GITHUB_REPOSITORY", "my-user/my-repo")
-	os.Setenv("INPUT_TOKEN", "ghp_1234567890abcdef1234567890abcdef12345678")
 	os.Setenv("GITHUB_WORKFLOW", "CI Build")
+
+	os.Setenv("INPUT_TOKEN", "ghp_1234567890abcdef1234567890abcdef12345678")
+
+	inputs := make(map[string]string)
+	inputs["var123"] = "NumberedValue"
+	inputs["custom"] = "CustomValue"
+	inputs["emptyVar"] = ""
+	inputs["var_name"] = "UnderValue"
+	inputs["dup"] = "Duplicate"
+	inputs["   "] = "SpaceVar"
+	inputs["verylongvariablenameindeed"] = "LongValue"
+
+	var buffer bytes.Buffer
+	json.NewEncoder(&buffer).Encode(inputs)
+	os.Setenv("INPUT_INPUTS", buffer.String())
 
 	// Since the env variables are not coming from the parent
 	// process and were instead set manually above, the github
 	// context variables need to be initialized again.
-	initGhContexts()
+	err := initGhContexts()
+	if err != nil {
+		t.Errorf("Error initializing github context: %s", err)
+		return
+	}
 
 	// Define test cases
 	testCases := []struct {
 		name           string
 		input          string
-		inputValues    map[core.InputId]interface{}
 		expectedOutput string
 	}{
 		{
 			name:           "Check github.repository",
 			input:          "Repository is ${{ github.repository }}.",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "Repository is my-user/my-repo.",
 		},
 		{
 			name:           "Check github.job",
 			input:          "Job name: ${{ github.job }}.",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "Job name: build.",
 		},
 		{
 			name:           "Check github.ref",
 			input:          "Reference: ${{ github.ref }}.",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "Reference: refs/heads/main.",
 		},
 		{
 			name:           "Check github.sha",
 			input:          "Commit SHA: ${{ github.sha }}.",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "Commit SHA: a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0.",
 		},
 		{
 			name:           "Check github.event",
 			input:          "Event name: ${{ github.event_name }}.",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "Event name: push.",
 		},
 		{
-			name:  "Variable with number",
-			input: "Number test: ${{ inputs.var123 }}.",
-			inputValues: map[core.InputId]interface{}{
-				"var123": "NumberedValue",
-			},
+			name:           "Variable with number",
+			input:          "Number test: ${{ inputs.var123 }}.",
 			expectedOutput: "Number test: NumberedValue.",
 		},
 		{
 			name:           "Multiple GitHub variables",
 			input:          "${{ github.job }} and ${{ github.workflow }}.",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "build and CI Build.",
 		},
 		{
-			name:  "Mixed GitHub and custom variables",
-			input: "Repo: ${{ github.repository }}, Custom: ${{ inputs.custom }}.",
-			inputValues: map[core.InputId]interface{}{
-				"custom": "CustomValue",
-			},
+			name:           "Mixed GitHub and custom variables",
+			input:          "Repo: ${{ github.repository }}, Custom: ${{ inputs.custom }}.",
 			expectedOutput: "Repo: my-user/my-repo, Custom: CustomValue.",
 		},
 		{
 			name:           "Variable at start",
 			input:          "${{ github.workflow }} - workflow",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "CI Build - workflow",
 		},
 		{
 			name:           "Variable at end",
 			input:          "End with - ${{ github.job }}",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "End with - build",
 		},
 		{
 			name:           "Multiple adjacent variables",
 			input:          "${{ github.job }}${{ github.workflow }}",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "buildCI Build",
 		},
 		{
-			name:  "Empty variable",
-			input: "This is empty: ${{ inputs.emptyVar }}.",
-			inputValues: map[core.InputId]interface{}{
-				"emptyVar": "",
-			},
+			name:           "Empty variable",
+			input:          "This is empty: ${{ inputs.emptyVar }}.",
 			expectedOutput: "This is empty: .",
 		},
 		{
 			name:           "Undefined variable",
 			input:          "This is ${{ inputs.undefined }}.",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "This is .",
 		},
 		{
-			name:  "Variable with underscore",
-			input: "Underscore: ${{ inputs.var_name }}.",
-			inputValues: map[core.InputId]interface{}{
-				"var_name": "UnderValue",
-			},
+			name:           "Variable with underscore",
+			input:          "Underscore: ${{ inputs.var_name }}.",
 			expectedOutput: "Underscore: UnderValue.",
 		},
 		{
 			name:           "Nonexistent GitHub context variable",
 			input:          "Nonexistent ${{ github.nonexistent }}.",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "Nonexistent .",
 		},
 		{
-			name:  "Multiple replacements with same key",
-			input: "${{ inputs.dup }} and ${{ inputs.dup }} again.",
-			inputValues: map[core.InputId]interface{}{
-				"dup": "Duplicate",
-			},
+			name:           "Multiple replacements with same key",
+			input:          "${{ inputs.dup }} and ${{ inputs.dup }} again.",
 			expectedOutput: "Duplicate and Duplicate again.",
 		},
 		{
-			name:  "Variable with only spaces (spaces must be ignored)",
-			input: "Just spaces: ${{ inputs.   }}.",
-			inputValues: map[core.InputId]interface{}{
-				"   ": "SpaceVar",
-			},
+			name:           "Variable with only spaces (spaces must be ignored)",
+			input:          "Just spaces: ${{ inputs.   }}.",
 			expectedOutput: "Just spaces: ${{ inputs.   }}.",
 		},
 		{
-			name:  "Long variable name",
-			input: "Long variable: ${{ inputs.verylongvariablenameindeed }}.",
-			inputValues: map[core.InputId]interface{}{
-				"verylongvariablenameindeed": "LongValue",
-			},
+			name:           "Long variable name",
+			input:          "Long variable: ${{ inputs.verylongvariablenameindeed }}.",
 			expectedOutput: "Long variable: LongValue.",
 		},
 		{
 			name:           "Check github.token",
 			input:          "Secret is ${{ github.token }}.",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "Secret is ghp_1234567890abcdef1234567890abcdef12345678.",
 		},
 		{
 			name:           "Check github.token",
 			input:          "Secret is ${{ secrets.GITHUB_TOKEN }}.",
-			inputValues:    map[core.InputId]interface{}{},
 			expectedOutput: "Secret is ghp_1234567890abcdef1234567890abcdef12345678.",
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			output := ReplaceContextVariables(tc.input, tc.inputValues)
+			output := ReplaceContextVariables(tc.input)
 			if output != tc.expectedOutput {
 				t.Errorf("Output should match expected output, but got: %s", output)
 			}

--- a/nodes/gh.go
+++ b/nodes/gh.go
@@ -17,7 +17,7 @@ var (
 
 	// This is the map of secrets that are available during the execution
 	// of the action graph. The values contain the context name and
-	// the secret value. Example: secrets.input1 github.token
+	// the secret value. Example: 'secrets.input1' or 'secrets.GITHUB_TOKEN'
 	ghSecrets = make(map[string]string, 0)
 
 	// this is the map of context variables that are available to the action
@@ -80,6 +80,7 @@ func initGhContexts() {
 			if len(pair) == 1 {
 				// empty secrets are valid
 				ghSecrets[pair[0]] = ""
+				os.Unsetenv(pair[0])
 			} else if len(pair) == 2 {
 				key := strings.TrimPrefix(strings.ToUpper(pair[0]), "SECRET_")
 				value := pair[1]

--- a/nodes/gh.go
+++ b/nodes/gh.go
@@ -4,7 +4,9 @@ package nodes
 
 import (
 	"actionforge/graph-runner/utils"
+	"encoding/json"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 )
@@ -20,8 +22,14 @@ var (
 	// the secret value. Example: 'secrets.input1' or 'secrets.GITHUB_TOKEN'
 	ghSecrets = make(map[string]string, 0)
 
-	// this is the map of context variables that are available to the action
+	// this is the map of 'github.xyz' context variables
 	ghContext = make(map[string]string)
+
+	// this is the map of all 'matrix.xyz' variables
+	ghMatrix = make(map[string]string)
+
+	// this is the map of all 'inputs.xyz' variables
+	ghInputs = make(map[string]string)
 )
 
 func AddGhSecret(name string, secret string) {
@@ -32,7 +40,28 @@ func RemoveGhSecret(name string) {
 	delete(ghSecrets, name)
 }
 
-func initGhContexts() {
+func decodeJsonFromEnv(e string, prefix string) (map[string]string, error) {
+	envMap := make(map[string]string, 0)
+	pair := strings.SplitN(e, "=", 2)
+	if len(pair) == 2 {
+		if pair[1] == "" {
+			return envMap, nil
+		}
+		var tmp map[string]string
+		err := json.NewDecoder(strings.NewReader(pair[1])).Decode(&tmp)
+		if err != nil {
+			return nil, err
+		}
+		for k, v := range tmp {
+			envMap[fmt.Sprintf("%s.%s", prefix, k)] = v
+		}
+		return envMap, nil
+	} else {
+		return nil, fmt.Errorf("Invalid %s: %s", prefix, pair[0])
+	}
+}
+
+func initGhContexts() error {
 
 	// For more information on the githubs context, see:
 	// https://docs.github.com/en/actions/learn-github-actions/contexts
@@ -74,7 +103,7 @@ func initGhContexts() {
 
 	ghActionsRuntimeToken = os.Getenv("ACTIONS_RUNTIME_TOKEN")
 
-	for _, env := range utils.GetSanitizedEnviron() {
+	for _, env := range os.Environ() {
 		if strings.HasPrefix(strings.ToUpper(env), "SECRET_") {
 			pair := strings.SplitN(env, "=", 2)
 			if len(pair) == 1 {
@@ -88,15 +117,40 @@ func initGhContexts() {
 				ghSecrets[key] = value
 				os.Unsetenv(pair[0])
 			} else {
-				fmt.Println("WARN: Invalid secret: ", pair[0])
+				return fmt.Errorf("Invalid secret: %s", pair[0])
+			}
+		} else if strings.HasPrefix(strings.ToUpper(env), "INPUT_MATRIX=") {
+			var err error
+			ghMatrix, err = decodeJsonFromEnv(env, "matrix")
+			if err != nil {
+				return err
+			}
+		} else if strings.HasPrefix(strings.ToUpper(env), "INPUT_INPUTS=") {
+			var err error
+			ghInputs, err = decodeJsonFromEnv(env, "inputs")
+			if err != nil {
+				return err
 			}
 		}
 	}
+
+	// The information in the inputs context and github.event.inputs context is identical
+	// except that the inputs context preserves Boolean values as Booleans instead of converting
+	// them to strings. TODO: (Seb) Change the ghInputs to map[string]interface{} to preserve
+	// the types for inputs.
+	for k, v := range ghSecrets {
+		ghContext[fmt.Sprintf("github.event.%s", k)] = v
+	}
+
+	return nil
 }
 
 func init() {
 
 	utils.LoadEnvOnce()
 
-	initGhContexts()
+	err := initGhContexts()
+	if err != nil {
+		log.Fatalf("Error initializing github context: %s", err)
+	}
 }

--- a/nodes/ngh-utils.go
+++ b/nodes/ngh-utils.go
@@ -2,9 +2,7 @@
 
 package nodes
 
-import "actionforge/graph-runner/core"
-
 // Dummy implementation if project isn't build with GitHub support
-func ReplaceContextVariables(input string, inputValues map[core.InputId]interface{}) string {
+func ReplaceContextVariables(input string) string {
 	return input
 }

--- a/nodes/run@v1.go
+++ b/nodes/run@v1.go
@@ -53,7 +53,7 @@ func (n *RunNode) ExecuteImpl(c core.ExecutionContext) error {
 	}
 
 	for i, env := range envs {
-		envs[i] = ReplaceContextVariables(env, n.GetInputValues())
+		envs[i] = ReplaceContextVariables(env)
 	}
 
 	env := append(envs, utils.GetSanitizedEnviron()...)

--- a/system_tests/cli_base_test.go
+++ b/system_tests/cli_base_test.go
@@ -42,6 +42,15 @@ func Test_Cli(t *testing.T) {
 }
 
 func Test_Freeze(t *testing.T) {
+	// Exclude test during local execution.
+	// The freeze command depends on the current
+	// commit being accessible as a zip archive on
+	// GitHub, which may not be the case for commits
+	// made locally but not yet pushed.
+	if os.Getenv("GITHUB_REF_NAME") == "" {
+		t.Skip("Skipping test locally")
+	}
+
 	actionHomeDir := utils.GetActionforgeDir()
 
 	err := os.RemoveAll(actionHomeDir)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -347,7 +347,8 @@ func GetSanitizedEnviron() []string {
 	env := os.Environ()
 	var sanitizedEnv []string
 	for _, e := range env {
-		if !strings.HasPrefix(e, "GRAPH_FILE=") {
+		if !strings.HasPrefix(e, "GRAPH_FILE=") &&
+			!strings.HasPrefix(e, "INPUT_") {
 			sanitizedEnv = append(sanitizedEnv, e)
 		}
 	}


### PR DESCRIPTION
This PR fixes an issue reported in https://github.com/actionforge/action/issues/7 where contexts for `inputs` and `matrix` could not be accessed. The following node inputs evaluate these context variables:

1. Env Array
2. GitHub Actions
3. Run (in the environment variables)

There are now multiple ways to access these.


## Inputs
```
on:
  workflow_dispatch:
    inputs:
      foo:
        description: 'Some value'
        required: true
```

Access 1: `${{ inputs.foo }}`
Access 2: `${{ github.event.inputs.foo }}`

```
  deploy:
    strategy:
      matrix:
        include:
          - image: "api_internal_development"
            environment: "Internal/Development"
          - image: "api_internal_staging"
            environment: "Internal/Staging" 
          - image: "api_internal_production"
            environment: "Internal/Production"
```

Access 1: `${{ matrix.include }}`