### PR TITLE
Fix secret node and add code signing and notarization on macOS

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -2,36 +2,41 @@ on: [push]
 
 jobs:
   build-test-publish:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
     name: Build and Publish
     permissions:
       packages: write
       contents: read
     steps:
       - name: Execute Action Graph
-        uses: actionforge/action@v0.8.30
+        uses: actionforge/action@46eca450335b4873aa06c1d5da7ded0f7654236c # v0.9.54
         with:
           graph_file: build.yml
         env:
           FREEZE_TEST: true
 
       - name: Test test_input_output.yml
-        uses: actionforge/action@6667acfef5cfb69d413683a8a87c1aa15412f649
+        if: ${{ matrix.os != 'macos-latest' }}
+        uses: actionforge/action@46eca450335b4873aa06c1d5da7ded0f7654236c # v0.9.54
         with:
-          # Use graph-runner in workdir directory
           runner_path: ${{ github.workspace }}/graph-runner
           graph_file: test_input_output.yml
 
       - name: Test test_env.yml
-        uses: actionforge/action@6667acfef5cfb69d413683a8a87c1aa15412f649
+        if: ${{ matrix.os != 'macos-latest' }}
+        uses: actionforge/action@46eca450335b4873aa06c1d5da7ded0f7654236c # v0.9.54
         with:
-          # Use graph-runner in workdir directory
           runner_path: ${{ github.workspace }}/graph-runner
           graph_file: test_env.yml
         env:
           MY_ENV: "hello world"
 
       - name: Build and Publish
-        uses: actionforge/action@v0.8.30
+        uses: actionforge/action@46eca450335b4873aa06c1d5da7ded0f7654236c # v0.9.54
         with:
+          runner_path: ${{ github.workspace }}/graph-runner
           graph_file: publish.yml
+          secrets: ${{ toJson(secrets) }}

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -15,8 +15,6 @@ jobs:
         uses: actionforge/action@46eca450335b4873aa06c1d5da7ded0f7654236c # v0.9.54
         with:
           graph_file: build.yml
-        env:
-          FREEZE_TEST: true
 
       - name: Test test_input_output.yml
         if: ${{ matrix.os != 'macos-latest' }}
@@ -31,6 +29,7 @@ jobs:
         with:
           runner_path: ${{ github.workspace }}/graph-runner
           graph_file: test_env.yml
+          secrets: ${{ toJson(secrets) }}
         env:
           MY_ENV: "hello world"
 

--- a/.github/workflows/graphs/build.yml
+++ b/.github/workflows/graphs/build.yml
@@ -28,7 +28,13 @@ executions:
       node: run-v1-blackberry-green-snake
       port: exec-success
     dst:
-      node: github-com-actions-upload-artifact-v3-1-3-purple-rabbit-brown
+      node: switch-platform-v1-dolphin-brown-banana
+      port: exec
+  - src:
+      node: switch-platform-v1-dolphin-brown-banana
+      port: exec-linux
+    dst:
+      node: gh-actions-upload-artifact-watermelon-brown-silver
       port: exec
 connections: []
 nodes:
@@ -72,17 +78,6 @@ nodes:
         go tool cover -html cover.out -o cover.html
     settings:
       folded: false
-  - id: github-com-actions-upload-artifact-v3-1-3-purple-rabbit-brown
-    type: >-
-      github.com/actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
-    position:
-      x: 1580
-      y: 2040
-    inputs:
-      name: cover
-      path: cover.html
-    settings:
-      folded: false
   - id: run-v1-blackberry-green-snake
     type: run@v1
     position:
@@ -90,6 +85,24 @@ nodes:
       y: 2070
     inputs:
       script: go build --tags=github_impl .
+    settings:
+      folded: false
+  - id: gh-actions-upload-artifact-watermelon-brown-silver
+    type: >-
+      github.com/actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+    position:
+      x: 1770
+      y: 1950
+    inputs:
+      name: cover
+      path: cover.html
+    settings:
+      folded: false
+  - id: switch-platform-v1-dolphin-brown-banana
+    type: switch-platform@v1
+    position:
+      x: 1530
+      y: 2050
     settings:
       folded: false
 registries:

--- a/.github/workflows/graphs/publish.yml
+++ b/.github/workflows/graphs/publish.yml
@@ -25,12 +25,6 @@ executions:
       node: gh-apple-actions-import-codesign-certs-v3-gold-orange-octopus
       port: exec
   - src:
-      node: branch-v1-pink-purple-koala
-      port: exec-then
-    dst:
-      node: switch-platform-v1-blueberry-purple-purple
-      port: exec
-  - src:
       node: parallel-exec-v1-cranberry-blueberry-orange
       port: exec[1]
     dst:
@@ -53,12 +47,6 @@ executions:
       port: exec-linux
     dst:
       node: parallel-exec-v1-cranberry-blueberry-orange
-      port: exec
-  - src:
-      node: gh-start
-      port: exec-on-push
-    dst:
-      node: gh-actions-setup-go-blue-grape-penguin
       port: exec
   - src:
       node: gh-actions-setup-go-blue-grape-penguin
@@ -137,6 +125,18 @@ executions:
       port: exec[2]
     dst:
       node: run-v1-cranberry-strawberry-butterfly
+      port: exec
+  - src:
+      node: branch-v1-pink-purple-koala
+      port: exec-then
+    dst:
+      node: gh-actions-setup-go-blue-grape-penguin
+      port: exec
+  - src:
+      node: gh-start
+      port: exec-on-push
+    dst:
+      node: branch-v1-pink-purple-koala
       port: exec
 connections:
   - src:
@@ -249,7 +249,7 @@ nodes:
   - id: branch-v1-pink-purple-koala
     type: branch@v1
     position:
-      x: 480
+      x: 270
       y: 1140
     settings:
       folded: false
@@ -347,7 +347,7 @@ nodes:
   - id: gh-actions-setup-go-blue-grape-penguin
     type: github.com/actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
     position:
-      x: 230
+      x: 330
       y: 700
     inputs:
       go-version: "1.22"

--- a/.github/workflows/graphs/publish.yml
+++ b/.github/workflows/graphs/publish.yml
@@ -1,12 +1,6 @@
 entry: gh-start
 executions:
   - src:
-      node: penguin-coconut-gray
-      port: exec-success
-    dst:
-      node: rabbit-dolphin-raspberry
-      port: exec
-  - src:
       node: parallel-exec-v1-cranberry-blueberry-orange
       port: exec[0]
     dst:
@@ -91,12 +85,6 @@ executions:
       node: run-v1-gold-pomegranate-butterfly
       port: exec
   - src:
-      node: run-v1-lion-panda-purple
-      port: exec-success
-    dst:
-      node: parallel-exec-v1-kiwi-penguin-apple
-      port: exec
-  - src:
       node: parallel-exec-v1-kiwi-penguin-apple
       port: exec[1]
     dst:
@@ -113,6 +101,42 @@ executions:
       port: exec-success
     dst:
       node: gh-actions-upload-artifact-giraffe-giraffe-cherry
+      port: exec
+  - src:
+      node: penguin-coconut-gray
+      port: exec-success
+    dst:
+      node: gh-actions-upload-artifact-red-kiwi-blackberry
+      port: exec
+  - src:
+      node: run-v1-lion-panda-purple
+      port: exec-success
+    dst:
+      node: parallel-exec-v1-kiwi-penguin-apple
+      port: exec
+  - src:
+      node: gh-actions-upload-artifact-red-kiwi-blackberry
+      port: exec
+    dst:
+      node: wait-for-v1-pineapple-snake-brown
+      port: exec[0]
+  - src:
+      node: gh-actions-upload-artifact-giraffe-giraffe-cherry
+      port: exec
+    dst:
+      node: wait-for-v1-pineapple-snake-brown
+      port: exec[1]
+  - src:
+      node: wait-for-v1-pineapple-snake-brown
+      port: exec
+    dst:
+      node: run-v1-cranberry-strawberry-butterfly
+      port: exec
+  - src:
+      node: parallel-exec-v1-kiwi-penguin-apple
+      port: exec[2]
+    dst:
+      node: run-v1-cranberry-strawberry-butterfly
       port: exec
 connections:
   - src:
@@ -170,17 +194,6 @@ nodes:
         actionforge/graph-runner/core.Production=true -X
         actionforge/graph-runner/core.Version=$GITHUB_REF_NAME"
         -tags=github_impl -o dist-linux/graph-runner-linux-x64 .
-    settings:
-      folded: false
-  - id: rabbit-dolphin-raspberry
-    type: >-
-      github.com/actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
-    position:
-      x: 2080
-      y: 1490
-    inputs:
-      name: graph-runner-linux-x64
-      path: dist-windows/graph-runner-linux-x64
     settings:
       folded: false
   - id: yellow-kangaroo-pineapple
@@ -256,7 +269,7 @@ nodes:
       github.com/docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
     position:
       x: 2120
-      y: 310
+      y: 180
     inputs:
       push: "true"
       context: .
@@ -365,8 +378,8 @@ nodes:
   - id: run-v1-lion-panda-purple
     type: run@v1
     position:
-      x: 2940
-      y: 2080
+      x: 2950
+      y: 2070
     inputs:
       script: >-
         zip -r graph-runner.zip ./dist-darwin
@@ -394,8 +407,8 @@ nodes:
     type: >-
       github.com/actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
     position:
-      x: 3760
-      y: 2330
+      x: 4040
+      y: 2350
     inputs:
       name: graph-runner-darwin-x64
       path: dist-darwin/graph-runner-darwin-x64
@@ -404,19 +417,20 @@ nodes:
   - id: parallel-exec-v1-kiwi-penguin-apple
     type: parallel-exec@v1
     position:
-      x: 3460
-      y: 2200
+      x: 3450
+      y: 1990
     outputs:
       exec[0]: ""
       exec[1]: ""
+      exec[2]: ""
     settings:
       folded: false
   - id: gh-actions-upload-artifact-pomegranate-snake-cranberry
     type: >-
       github.com/actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
     position:
-      x: 3760
-      y: 1940
+      x: 4030
+      y: 1870
     inputs:
       name: graph-runner-darwin-arm64
       path: dist-darwin/graph-runner-darwin-arm64
@@ -431,6 +445,41 @@ nodes:
     inputs:
       name: graph-runner-win32-x64
       path: dist-windows/graph-runner-win32-x64.exe
+    settings:
+      folded: false
+  - id: gh-actions-upload-artifact-red-kiwi-blackberry
+    type: >-
+      github.com/actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+    position:
+      x: 2110
+      y: 1400
+    inputs:
+      name: graph-runner-linux-x64
+      path: dist-linux/graph-runner-linux-x64
+    settings:
+      folded: false
+  - id: run-v1-cranberry-strawberry-butterfly
+    type: run@v1
+    position:
+      x: 3730
+      y: 1510
+    inputs:
+      script: |-
+        find dist-* -type f | while read -r file; do
+          sha256=$(shasum -a 256 "$file" | awk '{print $1}')
+          echo "$sha256  $file"
+        done
+    settings:
+      folded: false
+  - id: wait-for-v1-pineapple-snake-brown
+    type: wait-for@v1
+    position:
+      x: 2670
+      y: 1650
+    inputs:
+      after: 2
+      exec[0]: null
+      exec[1]: null
     settings:
       folded: false
 registries:

--- a/.github/workflows/graphs/publish.yml
+++ b/.github/workflows/graphs/publish.yml
@@ -1,42 +1,6 @@
 entry: gh-start
 executions:
   - src:
-      node: blue-monkey-tiger
-      port: exec
-    dst:
-      node: penguin-coconut-gray
-      port: exec
-  - src:
-      node: blue-monkey-tiger
-      port: exec[0]
-    dst:
-      node: penguin-coconut-gray
-      port: exec
-  - src:
-      node: blue-monkey-tiger
-      port: exec[1]
-    dst:
-      node: yellow-kangaroo-pineapple
-      port: exec
-  - src:
-      node: blue-monkey-tiger
-      port: exec[2]
-    dst:
-      node: giraffe-monkey-plum
-      port: exec
-  - src:
-      node: giraffe-monkey-plum
-      port: exec-success
-    dst:
-      node: orange-watermelon-lion
-      port: exec
-  - src:
-      node: yellow-kangaroo-pineapple
-      port: exec-success
-    dst:
-      node: blueberry-lemon-orange
-      port: exec
-  - src:
       node: penguin-coconut-gray
       port: exec-success
     dst:
@@ -49,24 +13,6 @@ executions:
       node: github-com-docker-login-action-v3-0-0-kiwi-giraffe-kiwi
       port: exec
   - src:
-      node: parallel-exec-v1-cranberry-blueberry-orange
-      port: exec[1]
-    dst:
-      node: blue-monkey-tiger
-      port: exec
-  - src:
-      node: gh-start
-      port: exec-on-push
-    dst:
-      node: branch-v1-pink-purple-koala
-      port: exec
-  - src:
-      node: branch-v1-pink-purple-koala
-      port: exec-then
-    dst:
-      node: parallel-exec-v1-cranberry-blueberry-orange
-      port: exec
-  - src:
       node: github-com-docker-login-action-v3-0-0-kiwi-giraffe-kiwi
       port: exec
     dst:
@@ -77,6 +23,96 @@ executions:
       port: exec
     dst:
       node: github-com-docker-build-push-action-v5-1-0-brown-orange-banana
+      port: exec
+  - src:
+      node: giraffe-monkey-plum
+      port: exec-success
+    dst:
+      node: gh-apple-actions-import-codesign-certs-v3-gold-orange-octopus
+      port: exec
+  - src:
+      node: branch-v1-pink-purple-koala
+      port: exec-then
+    dst:
+      node: switch-platform-v1-blueberry-purple-purple
+      port: exec
+  - src:
+      node: parallel-exec-v1-cranberry-blueberry-orange
+      port: exec[1]
+    dst:
+      node: penguin-coconut-gray
+      port: exec
+  - src:
+      node: parallel-exec-v1-cranberry-blueberry-orange
+      port: exec[2]
+    dst:
+      node: yellow-kangaroo-pineapple
+      port: exec
+  - src:
+      node: switch-platform-v1-blueberry-purple-purple
+      port: exec-macos
+    dst:
+      node: giraffe-monkey-plum
+      port: exec
+  - src:
+      node: switch-platform-v1-blueberry-purple-purple
+      port: exec-linux
+    dst:
+      node: parallel-exec-v1-cranberry-blueberry-orange
+      port: exec
+  - src:
+      node: gh-start
+      port: exec-on-push
+    dst:
+      node: gh-actions-setup-go-blue-grape-penguin
+      port: exec
+  - src:
+      node: gh-actions-setup-go-blue-grape-penguin
+      port: exec
+    dst:
+      node: switch-platform-v1-blueberry-purple-purple
+      port: exec
+  - src:
+      node: gh-apple-actions-import-codesign-certs-v3-gold-orange-octopus
+      port: exec
+    dst:
+      node: run-v1-pineapple-pear-peach
+      port: exec
+  - src:
+      node: run-v1-pineapple-pear-peach
+      port: exec-success
+    dst:
+      node: run-v1-lion-panda-purple
+      port: exec
+  - src:
+      node: switch-platform-v1-blueberry-purple-purple
+      port: exec-win
+    dst:
+      node: run-v1-gold-pomegranate-butterfly
+      port: exec
+  - src:
+      node: run-v1-lion-panda-purple
+      port: exec-success
+    dst:
+      node: parallel-exec-v1-kiwi-penguin-apple
+      port: exec
+  - src:
+      node: parallel-exec-v1-kiwi-penguin-apple
+      port: exec[1]
+    dst:
+      node: gh-actions-upload-artifact-pear-banana-monkey
+      port: exec
+  - src:
+      node: parallel-exec-v1-kiwi-penguin-apple
+      port: exec[0]
+    dst:
+      node: gh-actions-upload-artifact-pomegranate-snake-cranberry
+      port: exec
+  - src:
+      node: yellow-kangaroo-pineapple
+      port: exec-success
+    dst:
+      node: gh-actions-upload-artifact-giraffe-giraffe-cherry
       port: exec
 connections:
   - src:
@@ -91,42 +127,6 @@ connections:
     dst:
       node: branch-v1-pink-purple-koala
       port: condition
-  - src:
-      node: env-get-v1-strawberry-banana-cranberry
-      port: env
-    dst:
-      node: string-fmt-v1-giraffe-gray-plum
-      port: input[0]
-  - src:
-      node: env-get-v1-strawberry-banana-cranberry
-      port: env
-    dst:
-      node: string-fmt-v1-dolphin-monkey-grape
-      port: input[0]
-  - src:
-      node: env-get-v1-strawberry-banana-cranberry
-      port: env
-    dst:
-      node: string-fmt-v1-squirrel-strawberry-plum
-      port: input[0]
-  - src:
-      node: string-fmt-v1-dolphin-monkey-grape
-      port: result
-    dst:
-      node: orange-watermelon-lion
-      port: name
-  - src:
-      node: string-fmt-v1-giraffe-gray-plum
-      port: result
-    dst:
-      node: blueberry-lemon-orange
-      port: name
-  - src:
-      node: string-fmt-v1-squirrel-strawberry-plum
-      port: result
-    dst:
-      node: rabbit-dolphin-raspberry
-      port: name
   - src:
       node: string-fmt-v1-shark-orange-brown
       port: result
@@ -155,8 +155,8 @@ nodes:
   - id: gh-start
     type: gh-start@v1
     position:
-      x: 70
-      y: 1090
+      x: -160
+      y: 910
     settings:
       folded: true
   - id: penguin-coconut-gray
@@ -170,19 +170,17 @@ nodes:
         actionforge/graph-runner/core.Production=true -X
         actionforge/graph-runner/core.Version=$GITHUB_REF_NAME"
         -tags=github_impl -o dist-linux/graph-runner-linux-x64 .
-
-        tar -cvf graph-runner-linux.tar -C dist-linux .
     settings:
       folded: false
   - id: rabbit-dolphin-raspberry
     type: >-
       github.com/actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
     position:
-      x: 2060
-      y: 1980
+      x: 2080
+      y: 1490
     inputs:
       name: graph-runner-linux-x64
-      path: graph-runner-linux.tar
+      path: dist-windows/graph-runner-linux-x64
     settings:
       folded: false
   - id: yellow-kangaroo-pineapple
@@ -195,18 +193,7 @@ nodes:
         GOOS=windows GOARCH=amd64 go build -ldflags "-X
         actionforge/graph-runner/core.Production=true -X
         actionforge/graph-runner/core.Version=$GITHUB_REF_NAME"
-        -tags=github_impl -o dist-windows/graph-runner-windows-x64.exe .
-    settings:
-      folded: false
-  - id: blueberry-lemon-orange
-    type: >-
-      github.com/actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
-    position:
-      x: 2060
-      y: 2280
-    inputs:
-      name: graph-runner-windows-x64
-      path: dist-windows/graph-runner-windows-x64.exe
+        -tags=github_impl -o dist-windows/graph-runner-win32-x64.exe .
     settings:
       folded: false
   - id: giraffe-monkey-plum
@@ -219,42 +206,18 @@ nodes:
         GOOS=darwin GOARCH=arm64 go build -ldflags "-X
         actionforge/graph-runner/core.Production=true -X
         actionforge/graph-runner/core.Version=$GITHUB_REF_NAME"
-        -tags=github_impl -o dist-macos/graph-runner-macos-arm64 .
+        -tags=github_impl -o dist-darwin/graph-runner-darwin-arm64 .
 
         GOOS=darwin GOARCH=amd64 go build -ldflags "-X
         actionforge/graph-runner/core.Production=true -X
         actionforge/graph-runner/core.Version=$GITHUB_REF_NAME"
-        -tags=github_impl -o dist-macos/graph-runner-macos-x64 .
-
-        tar -cvf graph-runner-macos.tar -C dist-macos .
-    settings:
-      folded: false
-  - id: orange-watermelon-lion
-    type: >-
-      github.com/actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
-    position:
-      x: 2060
-      y: 2580
-    inputs:
-      name: graph-runner-macos
-      path: graph-runner-macos.tar
-    settings:
-      folded: false
-  - id: blue-monkey-tiger
-    type: parallel-exec@v1
-    position:
-      x: 1310
-      y: 1890
-    outputs:
-      exec[0]: ""
-      exec[1]: ""
-      exec[2]: ""
+        -tags=github_impl -o dist-darwin/graph-runner-darwin-x64 .
     settings:
       folded: false
   - id: env-get-v1-rabbit-octopus-gold
     type: env-get@v1
     position:
-      x: 30
+      x: -230
       y: 1300
     inputs:
       env: GITHUB_REF
@@ -263,8 +226,8 @@ nodes:
   - id: string-match-v1-pomegranate-raspberry-silver
     type: string-match@v1
     position:
-      x: 290
-      y: 1310
+      x: 110
+      y: 1240
     inputs:
       op: startswith
       str2: refs/tags/
@@ -273,65 +236,27 @@ nodes:
   - id: branch-v1-pink-purple-koala
     type: branch@v1
     position:
-      x: 650
+      x: 480
       y: 1140
     settings:
       folded: false
   - id: parallel-exec-v1-cranberry-blueberry-orange
     type: parallel-exec@v1
     position:
-      x: 860
-      y: 1100
+      x: 940
+      y: 840
     outputs:
       exec[0]: ""
       exec[1]: ""
-    settings:
-      folded: false
-  - id: string-fmt-v1-squirrel-strawberry-plum
-    type: string-fmt@v1
-    position:
-      x: 1610
-      y: 2520
-    inputs:
-      input[0]: null
-      fmt: graph-runner-linux-%v.tar
-    settings:
-      folded: false
-  - id: string-fmt-v1-giraffe-gray-plum
-    type: string-fmt@v1
-    position:
-      x: 1610
-      y: 2730
-    inputs:
-      input[0]: null
-      fmt: graph-runner-windows-x64-%v
-    settings:
-      folded: false
-  - id: string-fmt-v1-dolphin-monkey-grape
-    type: string-fmt@v1
-    position:
-      x: 1610
-      y: 2940
-    inputs:
-      input[0]: null
-      fmt: graph-runner-macos-%v.tar
-    settings:
-      folded: false
-  - id: env-get-v1-strawberry-banana-cranberry
-    type: env-get@v1
-    position:
-      x: 1280
-      y: 2840
-    inputs:
-      env: GITHUB_REF_NAME
+      exec[2]: ""
     settings:
       folded: false
   - id: github-com-docker-build-push-action-v5-1-0-brown-orange-banana
     type: >-
       github.com/docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56
     position:
-      x: 2060
-      y: 800
+      x: 2120
+      y: 310
     inputs:
       push: "true"
       context: .
@@ -352,8 +277,8 @@ nodes:
   - id: github-com-docker-login-action-v3-0-0-kiwi-giraffe-kiwi
     type: github.com/docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d
     position:
-      x: 1220
-      y: 560
+      x: 1280
+      y: 810
     inputs:
       registry: ghcr.io
       username: ${{ github.actor }}
@@ -363,8 +288,8 @@ nodes:
   - id: env-get-v1-gold-panda-coconut
     type: env-get@v1
     position:
-      x: 1280
-      y: 1160
+      x: 1310
+      y: 1140
     inputs:
       env: GITHUB_REPOSITORY
     settings:
@@ -372,8 +297,8 @@ nodes:
   - id: env-get-v1-penguin-pineapple-pear
     type: env-get@v1
     position:
-      x: 1280
-      y: 1260
+      x: 1320
+      y: 1290
     inputs:
       env: GITHUB_REF_NAME
     settings:
@@ -388,8 +313,129 @@ nodes:
       platforms: linux/amd64,linux/arm64,linux/arm/v7
     settings:
       folded: false
+  - id: gh-apple-actions-import-codesign-certs-v3-gold-orange-octopus
+    type: >-
+      github.com/apple-actions/import-codesign-certs@63fff01cd422d4b7b855d40ca1e9d34d2de9427d
+    position:
+      x: 2050
+      y: 2160
+    inputs:
+      p12-password: ${{ secrets.APPLE_P12_PASSWORD }}
+      p12-file-base64: ${{ secrets.APPLE_P12_CERTIFICATE_BASE64 }}
+    settings:
+      folded: false
+  - id: switch-platform-v1-blueberry-purple-purple
+    type: switch-platform@v1
+    position:
+      x: 690
+      y: 930
+    settings:
+      folded: false
+  - id: gh-actions-setup-go-blue-grape-penguin
+    type: github.com/actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7
+    position:
+      x: 230
+      y: 700
+    inputs:
+      go-version: "1.22"
+    settings:
+      folded: false
+  - id: run-v1-pineapple-pear-peach
+    type: run@v1
+    position:
+      x: 2440
+      y: 2120
+    inputs:
+      script: >-
+        codesign --keychain signing_temp.keychain --deep --force --verbose
+        --sign "Developer ID Application: Actionforge Inc. (D9L94G8QN4)"
+        --timestamp --options runtime --entitlements ./entitlement.plist
+        ./dist-darwin/graph-runner-darwin-arm64
+
+        codesign --keychain signing_temp.keychain --deep --force --verbose
+        --sign "Developer ID Application: Actionforge Inc. (D9L94G8QN4)"
+        --timestamp --options runtime --entitlements ./entitlement.plist
+        ./dist-darwin/graph-runner-darwin-x64
+      env:
+        - >-
+          APPLE_DEVELOPER_ID="Developer ID Application: Actionforge Inc.
+          (D9L94G8QN4)"
+    settings:
+      folded: false
+  - id: run-v1-lion-panda-purple
+    type: run@v1
+    position:
+      x: 2940
+      y: 2080
+    inputs:
+      script: >-
+        zip -r graph-runner.zip ./dist-darwin
+
+        xcrun notarytool submit ./graph-runner.zip --team-id $APPLE_TEAM_ID
+        --apple-id $APPLE_ID --password $APPLE_PASSWORD --wait
+      env:
+        - APPLE_TEAM_ID=D9L94G8QN4
+        - APPLE_ID=dev@actionforge.dev
+        - APPLE_PASSWORD=${{ secrets.APPLE_ID_PASSWORD }}
+    settings:
+      folded: false
+  - id: run-v1-gold-pomegranate-butterfly
+    type: run@v1
+    position:
+      x: 940
+      y: 510
+    inputs:
+      script: |-
+        echo "Windows is built by Linux"
+        echo 1
+    settings:
+      folded: false
+  - id: gh-actions-upload-artifact-pear-banana-monkey
+    type: >-
+      github.com/actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+    position:
+      x: 3760
+      y: 2330
+    inputs:
+      name: graph-runner-darwin-x64
+      path: dist-darwin/graph-runner-darwin-x64
+    settings:
+      folded: false
+  - id: parallel-exec-v1-kiwi-penguin-apple
+    type: parallel-exec@v1
+    position:
+      x: 3460
+      y: 2200
+    outputs:
+      exec[0]: ""
+      exec[1]: ""
+    settings:
+      folded: false
+  - id: gh-actions-upload-artifact-pomegranate-snake-cranberry
+    type: >-
+      github.com/actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+    position:
+      x: 3760
+      y: 1940
+    inputs:
+      name: graph-runner-darwin-arm64
+      path: dist-darwin/graph-runner-darwin-arm64
+    settings:
+      folded: false
+  - id: gh-actions-upload-artifact-giraffe-giraffe-cherry
+    type: >-
+      github.com/actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+    position:
+      x: 2080
+      y: 1780
+    inputs:
+      name: graph-runner-win32-x64
+      path: dist-windows/graph-runner-win32-x64.exe
+    settings:
+      folded: false
 registries:
   - github.com/docker/build-push-action@v5.1.0
   - github.com/docker/login-action@v3.0.0
   - github.com/docker/setup-buildx-action@v3.0.0
+  - github.com/apple-actions/import-codesign-certs@v3
 description: ""

--- a/.github/workflows/graphs/test_env.yml
+++ b/.github/workflows/graphs/test_env.yml
@@ -1,12 +1,6 @@
 entry: start
 executions:
   - src:
-      node: start
-      port: exec
-    dst:
-      node: run-v1-apple-silver-lion
-      port: exec
-  - src:
       node: gh-actionforge-test-action-node-main-lemon-penguin-yellow
       port: exec
     dst:
@@ -29,12 +23,6 @@ executions:
       port: exec-success
     dst:
       node: run-v1-snake-squirrel-shark
-      port: exec
-  - src:
-      node: run-v1-apple-silver-lion
-      port: exec-success
-    dst:
-      node: parallel-exec-v1-blackberry-orange-coconut
       port: exec
   - src:
       node: parallel-exec-v1-blackberry-orange-coconut
@@ -60,6 +48,24 @@ executions:
     dst:
       node: run-v1-yellow-squirrel-orange
       port: exec
+  - src:
+      node: run-v1-apple-silver-lion
+      port: exec-success
+    dst:
+      node: parallel-exec-v1-blackberry-orange-coconut
+      port: exec
+  - src:
+      node: run-v1-pomegranate-squirrel-squirrel
+      port: exec-success
+    dst:
+      node: run-v1-apple-silver-lion
+      port: exec
+  - src:
+      node: start
+      port: exec
+    dst:
+      node: run-v1-pomegranate-squirrel-squirrel
+      port: exec
 connections:
   - src:
       node: start
@@ -67,12 +73,30 @@ connections:
     dst:
       node: run-v1-apple-silver-lion
       port: env
+  - src:
+      node: gh-secret-v1-tiger-gold-plum
+      port: secret
+    dst:
+      node: string-fmt-v1-mango-strawberry-rabbit
+      port: input[0]
+  - src:
+      node: string-fmt-v1-mango-strawberry-rabbit
+      port: result
+    dst:
+      node: env-array-v1-elephant-brown-raspberry
+      port: env[0]
+  - src:
+      node: env-array-v1-elephant-brown-raspberry
+      port: env
+    dst:
+      node: run-v1-pomegranate-squirrel-squirrel
+      port: env
 nodes:
   - id: start
     type: start@v1
     position:
-      x: 10
-      y: 600
+      x: -800
+      y: 690
     settings:
       folded: false
   - id: gh-actionforge-test-action-node-main-lemon-penguin-yellow
@@ -90,8 +114,8 @@ nodes:
   - id: run-v1-apple-silver-lion
     type: run@v1
     position:
-      x: 230
-      y: 480
+      x: 200
+      y: 530
     inputs:
       script: |
         input1="hello world"
@@ -138,8 +162,8 @@ nodes:
   - id: parallel-exec-v1-blackberry-orange-coconut
     type: parallel-exec@v1
     position:
-      x: 540
-      y: 440
+      x: 580
+      y: 450
     outputs:
       exec[0]: ""
       exec[1]: ""
@@ -240,6 +264,48 @@ nodes:
             echo "MY_ENV is not correctly set, got: '$MY_ENV'"
             exit 1
         fi
+    settings:
+      folded: false
+  - id: gh-secret-v1-tiger-gold-plum
+    type: gh-secret@v1
+    position:
+      x: -1160
+      y: 1000
+    inputs:
+      name: APPLE_ID_PASSWORD
+    settings:
+      folded: false
+  - id: run-v1-pomegranate-squirrel-squirrel
+    type: run@v1
+    position:
+      x: -140
+      y: 550
+    inputs:
+      script: |-
+        if [ "$SECRET1" != "$SECRET2" ]; then
+          echo "secrets are not equal"
+          exit 1
+        fi
+    settings:
+      folded: false
+  - id: env-array-v1-elephant-brown-raspberry
+    type: env-array@v1
+    position:
+      x: -390
+      y: 830
+    inputs:
+      env[0]: ""
+      env[1]: SECRET2=${{ secrets.APPLE_ID_PASSWORD }}
+    settings:
+      folded: false
+  - id: string-fmt-v1-mango-strawberry-rabbit
+    type: string-fmt@v1
+    position:
+      x: -760
+      y: 900
+    inputs:
+      input[0]: null
+      fmt: SECRET1=%v
     settings:
       folded: false
 registries:

--- a/entitlement.plist
+++ b/entitlement.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>


### PR DESCRIPTION
This PR includes a fix and an update to the workflow. Specifically, it addresses a bug in the secret node that caused it to return empty values.

Additionally, macOS binaries are now code signed and notarized.